### PR TITLE
Initial

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+rebuild:
+	node-gyp rebuild

--- a/README.md
+++ b/README.md
@@ -1,0 +1,150 @@
+# modern syslog - streaming, async, native, uses nan
+
+This is the only syslog library that:
+
+- Uses native bindings to the libc syslog API.
+- Is async, because the libc APIs can block on localhost IPC under load, but
+  that shouldn't block your app.
+- Can be used as a stream.
+- Uses nan, so supports node and io.js, and will continue to do so.
+
+Default mask depends on system.
+
+## Installation
+
+    npm install --save modern-syslog
+
+## API
+
+For detailed descriptions of the core functions, see [man 3
+syslog](http://man7.org/linux/man-pages/man3/syslog.3.html).
+
+Note that syslog functions cannot fail, and neither throw errors, nor callback
+with errors. This is consistent with the core funtions, which do not have error
+return values.
+
+### log(priority, msg, callback)
+
+- `priority` {String|Number} OR of a level, and optionally, a facility.
+- `msg` {String|Buffer} Message to log.
+- `callback` {Function} Called after message is logged (no arguments).
+
+`priority` can be a String, in which case it will be looked up in
+`syslog.level`. It can also be a Number, in which case it is expected to be
+a numeric value, such as `syslog.level.LOG_INFO`, optionally ORed with a
+a numeric facility, such as `syslog.facility.LOG_LOCAL2`.
+
+See below for formatted version of `log()`.
+
+### emerg(fmt, ...)
+### alert(fmt, ...)
+### crit(fmt, ...)
+### error(fmt, ...)
+### err(fmt, ...)
+### warn(fmt, ...)
+### warning(fmt, ...)
+### note(fmt, ...)
+### notice(fmt, ...)
+### info(fmt, ...)
+### debug(fmt, ...)
+
+- `fmt` {String} Arguments are formatted as `msg`, and passed to `log()`.
+
+Convenience functions, log level is pre-defined, facility uses default, either
+system default or that provided to `open()`, and message is formatted with
+`util.format()`.
+
+### new Stream(level, [facility])
+
+- `level` {String|Number} Level to log at.
+- `facility` {String|Number} Facility to log with, optional.
+
+Returns a writeable stream that logs all messages at the specified level and
+facility.
+
+### open(ident, option, facility)
+
+- `ident` {String} Prepended to every message, usually program name.
+- `option` {Number} OR of flags from `syslog.options`.
+- `facility` {String|Number} Default facility to be used by `log()`.
+
+Set up defaults for log.
+
+Calling `open()` is optional, all arguments are provided with defaults, though
+the defaults depend on the system (see man page).
+
+### close()
+
+Close the socket to the syslog system.
+
+Calling `close()` is optional, the socket is closed automatically by the
+system on exit.
+
+### upto(level)
+
+- `level` {String|Number} Level to log up to.
+
+Log all levels upto and including `level`.
+
+### setmask(mask)
+
+- `mask` {Number} OR of levels that should be logged.
+
+Not convenient to use but part of the low-level syslog API. See syslog man page
+for details, and consider using `upto()` for most common use-cases.
+
+### curmask()
+
+Returns current log mask, see `setmask()`.
+
+## Properties
+
+Syslog properties are defined as a bi-directional map from String to Number, and
+from Number to String, so:
+
+- `syslog.level.LOG_DEBUG`: `7`, the numeric value of `LOG_DEBUG`
+- `syslog.level[7]`: `'LOG_DEBUG'`, string value of level `7`
+
+### syslog.level
+
+Levels are listed from highest priority, to lowest:
+
+- `LOG_EMERG`: System is unusable.
+- `LOG_ALERT`: Action must be taken immediately.
+- `LOG_CRIT`: Critical condition.
+- `LOG_ERR`: Error condition.
+- `LOG_WARNING`: Warning condition.
+- `LOG_NOTICE`: Normal, but significant, condition.
+- `LOG_INFO`: Informational message.
+- `LOG_DEBUG`: Debug-level message.
+
+### syslog.option
+
+Object of properties:
+
+- `LOG_CONS`: Log to console if there is error logging to syslog.
+- `LOG_PERROR`: Log to stderr as well as syslog.
+- `LOG_PID`: Log process' PID with each message.
+
+### syslog.facility
+
+- `LOG_AUTH`
+- `LOG_AUTHPRIV` (not defined on all systems)
+- `LOG_CRON`
+- `LOG_DAEMON`
+- `LOG_FTP` (not defined on all systems)
+- `LOG_KERN`
+- `LOG_LOCAL0`
+- `LOG_LOCAL1`
+- `LOG_LOCAL2`
+- `LOG_LOCAL3`
+- `LOG_LOCAL4`
+- `LOG_LOCAL5`
+- `LOG_LOCAL6`
+- `LOG_LOCAL7`
+- `LOG_LPR`
+- `LOG_MAIL`
+- `LOG_NEWS`
+- `LOG_SYSLOG`
+- `LOG_USER`
+- `LOG_UUCP`

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,0 +1,14 @@
+{
+  "targets": [
+    {
+      "target_name": "core",
+      "sources": [
+        "core.cc"
+      ],
+      "include_dirs"  : [
+            "<!(node -e \"require('nan')\")"
+      ],
+      "cflags": ["-g"]
+    }
+  ]
+}

--- a/core.cc
+++ b/core.cc
@@ -1,0 +1,181 @@
+#include <node.h>
+#include <nan.h>
+#include <syslog.h>
+
+using v8::Function;
+using v8::FunctionTemplate;
+using v8::Handle;
+using v8::Local;
+using v8::Null;
+using v8::Number;
+using v8::Object;
+using v8::String;
+using v8::Value;
+
+namespace {
+
+class Worker: public NanAsyncWorker {
+    public:
+        Worker(NanCallback *callback, int priority, char* message)
+            : NanAsyncWorker(callback), priority(priority), message(message) {
+            }
+        ~Worker() {
+            delete[] message;
+        }
+
+        void Execute() {
+            syslog(priority, "%s", message);
+        }
+
+        void HandleOKCallback() {
+            NanScope();
+
+            if(!callback->IsEmpty())
+                callback->Call(0, NULL);
+        };
+
+    private:
+        int priority;
+        char* message;
+};
+
+static char ident[1024];
+
+// wrap: void openlog(const char *ident, int option, int facility);
+NAN_METHOD(OpenLog) {
+    NanScope();
+
+    // openlog requires ident be statically allocated. Write doesn't guarantee
+    // NULL-termination, so preserve last byte as NULL.
+    args[0]->ToString()->WriteUtf8(ident, sizeof(ident)-1);
+    int option = args[1]->ToInt32()->Value();
+    int facility = args[2]->ToInt32()->Value();
+
+    openlog(ident, option, facility);
+
+    NanReturnUndefined();
+}
+
+static char* dupBuf(const Handle<Value>& arg) {
+    const char* mem = node::Buffer::Data(arg);
+    size_t memsz = node::Buffer::Length(arg);
+    char* s = new char[memsz + 1];
+    memcpy(s, mem, memsz);
+    s[memsz] = 0;
+    return s;
+}
+
+static char* dupStr(const Local<String>& m) {
+    if(m.IsEmpty())
+        return NULL;
+
+    // Exact calculation of UTF length involves double traversal. Avoid this
+    // because we know UTF8 expansion is < 4 bytes out per byte in.
+    char* s = new char[m->Length() * 4];
+    m->WriteUtf8(s);
+    return s;
+}
+
+// wrap: void syslog(int priority, const char *format, ...);
+NAN_METHOD(SysLog) {
+    NanScope();
+
+    int priority = args[0]->ToInt32()->Value();
+    char* message = NULL;
+    NanCallback *callback = new NanCallback(args[2].As<Function>());
+
+    if(node::Buffer::HasInstance(args[1])) {
+        message = dupBuf(args[1]);
+    } else {
+        message = dupStr(args[1]->ToString());
+    }
+
+    if (message) {
+        NanAsyncQueueWorker(new Worker(callback, priority, message));
+    } else if(!callback->IsEmpty()) {
+        callback->Call(0, NULL);
+    }
+
+    NanReturnUndefined();
+}
+
+// wrap: int setlogmask(int mask);
+NAN_METHOD(SetLogMask) {
+    NanScope();
+
+    int mask = args[0]->ToInt32()->Value();
+    int last = setlogmask(mask);
+
+    NanReturnValue(NanNew<Number>(last));
+}
+
+// wrap: void closelog(void);
+NAN_METHOD(CloseLog) {
+    NanScope();
+
+    closelog();
+
+    NanReturnUndefined();
+}
+
+void Init(Local<Object> exports) {
+#define EXPORT(N, F) \
+    exports->Set(NanNew<String>(N), \
+            NanNew<FunctionTemplate>(F)->GetFunction())
+
+    EXPORT("openlog", OpenLog);
+    EXPORT("syslog", SysLog);
+    EXPORT("setlogmask", SetLogMask);
+    EXPORT("closelog", CloseLog);
+
+    Local<Object> where = NanNew<Object>();
+#define DEFINE(N) where->Set(NanNew<String>(#N), NanNew<Number>(N))
+
+    // option argument to openlog() is an OR of any of these:
+    exports->Set(NanNew<String>("option"), where = NanNew<Object>());
+    DEFINE(LOG_CONS);
+    DEFINE(LOG_NDELAY);
+    DEFINE(LOG_PERROR);
+    DEFINE(LOG_PID);
+
+    // facility argument to openlog() is any ONE of these:
+    exports->Set(NanNew<String>("facility"), where = NanNew<Object>());
+    DEFINE(LOG_AUTH);
+#ifdef LOG_AUTHPRIV
+    DEFINE(LOG_AUTHPRIV);
+#endif
+    DEFINE(LOG_CRON);
+    DEFINE(LOG_DAEMON);
+#ifdef LOG_FTP
+    DEFINE(LOG_FTP);
+#endif
+    DEFINE(LOG_KERN);
+    DEFINE(LOG_LOCAL0);
+    DEFINE(LOG_LOCAL1);
+    DEFINE(LOG_LOCAL2);
+    DEFINE(LOG_LOCAL3);
+    DEFINE(LOG_LOCAL4);
+    DEFINE(LOG_LOCAL5);
+    DEFINE(LOG_LOCAL6);
+    DEFINE(LOG_LOCAL7);
+    DEFINE(LOG_LPR);
+    DEFINE(LOG_MAIL);
+    DEFINE(LOG_NEWS);
+    DEFINE(LOG_SYSLOG);
+    DEFINE(LOG_USER);
+    DEFINE(LOG_UUCP);
+
+    // priority argument to syslog() is an OR of a facility and ONE log level:
+    exports->Set(NanNew<String>("level"), where = NanNew<Object>());
+    DEFINE(LOG_EMERG);
+    DEFINE(LOG_ALERT);
+    DEFINE(LOG_CRIT);
+    DEFINE(LOG_ERR);
+    DEFINE(LOG_WARNING);
+    DEFINE(LOG_NOTICE);
+    DEFINE(LOG_INFO);
+    DEFINE(LOG_DEBUG);
+}
+}
+
+NODE_MODULE(core, Init);

--- a/index.js
+++ b/index.js
@@ -1,3 +1,125 @@
-var core = require('./build/Release/core.node');
+'use strict';
 
+var Writable = require('stream').Writable;
+var core = require('./build/Release/core.node');
+var inherits = require('util').inherits;
+var fmt = require('util').format;
+
+// Direct access to the core binding
 exports.core = core;
+
+// Constants
+exports.option = core.option;
+exports.facility = core.facility;
+exports.level = core.level;
+
+// High-level API, remove the redundant 'log' from method names.
+exports.open = open;
+exports.log = log;
+exports.upto = upto;
+exports.curmask = curmask;
+exports.close = core.closelog;
+exports.Stream = Stream;
+
+function open(ident, option, facility) {
+  // XXX(sam) would be nice to allow single strings for option
+  core.openlog(ident, option, toFacility(facility));
+}
+
+function log(level, msg, callback) {
+  core.syslog(toLevel(level), msg, callback);
+}
+
+function wrap(name, level) {
+  level = core.level[level];
+  exports[name] = function(msg) {
+    core.syslog(level, fmt.apply(null, arguments));
+  };
+}
+
+wrap('emerg', 'LOG_EMERG');
+wrap('alert', 'LOG_ALERT');
+wrap('crit', 'LOG_CRIT');
+wrap('error', 'LOG_ERR');
+wrap('err', 'LOG_ERR');
+wrap('warn', 'LOG_WARNING');
+wrap('warning', 'LOG_WARNING');
+wrap('note', 'LOG_NOTICE');
+wrap('notice', 'LOG_NOTICE');
+wrap('info', 'LOG_INFO');
+wrap('debug', 'LOG_DEBUG');
+
+// Low-level API
+exports.setmask = core.setlogmask;
+exports.toLevel = toLevel;
+exports.toFacility = toFacility;
+exports.logMask = logMask;
+exports.logUpto = logUpto;
+
+// Invert constants, so its easy to look the string up by the value.
+function invert(obj) {
+  for (var key in obj) {
+    var val = obj[key]
+    obj[val] = key;
+  }
+}
+
+invert(exports.option);
+invert(exports.facility);
+invert(exports.level);
+
+// setlogmask() is too painful to use, most systems have a LOG_UPTO(level)
+// macro, we'll just export upto() directly, its what most users will want.
+function upto(level) {
+  return core.setlogmask(logUpto(level));
+}
+
+// Linux allows calling setmask(0) to get the current mask, but OS X does not,
+// so make a curmask() to smooth this over.
+
+function curmask() {
+  var cur = core.setlogmask(0);
+  core.setlogmask(cur);
+  return cur;
+}
+
+// Writable stream for syslog.
+
+function Stream(level, facility) {
+  if (!(this instanceof Stream))
+      return new Stream(level, facility);
+
+  this.priority = toLevel(level) | toFacility(facility);
+
+  Writable.apply(this);
+}
+
+inherits(Stream, Writable);
+
+Stream.prototype._write = function(chunk, encoding, callback) {
+  core.syslog(this.priority, chunk, callback);
+};
+
+// Low-level API
+
+function toLevel(level) {
+  if (typeof level === 'string' && level in core.level)
+    return core.level[level];
+
+  return level;
+}
+
+function toFacility(facility) {
+  if (facility in core.facility)
+    return core.facility[facility];
+
+  return facility;
+}
+
+function logMask(level) {
+  return 1 << toLevel(level);
+}
+
+function logUpto(level) {
+  return (1 << (toLevel(level) + 1)) - 1;
+}

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+var core = require('./build/Release/core.node');
+
+exports.core = core;

--- a/package.json
+++ b/package.json
@@ -3,9 +3,18 @@
   "version": "1.0.0-1",
   "description": "modern syslog - streaming, async, uses nan",
   "main": "index.js",
+  "os": [
+    "!win32"
+  ],
   "scripts": {
     "test": "tap test-*.js"
   },
   "author": "Sam Roberts <sam@strongloop.com>",
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "tap": "^0.6.0"
+  },
+  "dependencies": {
+    "nan": "^1.6.2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -7,11 +7,12 @@
     "!win32"
   ],
   "scripts": {
-    "test": "tap test-*.js"
+    "test": "tap test/test-*.js"
   },
   "author": "Sam Roberts <sam@strongloop.com>",
   "license": "MIT",
   "devDependencies": {
+    "debug": "^2.1.2",
     "tap": "^0.6.0"
   },
   "dependencies": {

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -1,0 +1,31 @@
+var fmt = require('util').format;
+var syslog = require('../');
+var tap = require('tap');
+
+tap.test('core properties exist', function(t) {
+  t.assert(syslog.core);
+  t.assert(syslog.core.openlog);
+  t.assert(syslog.core.syslog);
+  t.assert(syslog.core.setlogmask);
+  t.assert(syslog.core.closelog);
+  t.assert(syslog.core.option.LOG_PID);
+  t.assert(syslog.core.facility.LOG_LOCAL0);
+  t.assert(syslog.core.level.LOG_DEBUG);
+  t.end();
+});
+
+function accept(m) {
+  tap.test(fmt('core syslog accepts %j', m), function(t) {
+    t.plan(1);
+    syslog.core.syslog(syslog.core.level.LOG_DEBUG, m, function() {
+      t.assert(true, 'called back');
+    });
+  });
+}
+
+accept('string');
+accept(Buffer('buffer'));
+accept(undefined);
+accept(null);
+accept({some: 5});
+accept(function fn() {});

--- a/test/test-openlog.js
+++ b/test/test-openlog.js
@@ -1,0 +1,14 @@
+var assert = require('assert');
+var syslog = require('../');
+var o = syslog.option;
+var f = syslog.facility;
+
+syslog.open('June', o.LOG_PERROR + o.LOG_PID, f.LOG_LOCAL1);
+syslog.upto('LOG_DEBUG');
+console.error('Expect on stderr a greeting to June with a PID:');
+syslog.log('LOG_DEBUG', 'Hi, June', function() {
+  syslog.open('Leonie', o.LOG_PERROR, f.LOG_LOCAL2);
+  syslog.upto('LOG_DEBUG');
+  console.error('Expect on stderr a greeting to Leonie without a PID:');
+  syslog.debug('Hi, %s', 'Leonie');
+});

--- a/test/test-setmask.js
+++ b/test/test-setmask.js
@@ -1,0 +1,86 @@
+'use strict';
+
+var assert = require('assert');
+var debug = require('debug')('modern-syslog:test');
+var syslog = require('../');
+var tap = require('tap');
+
+var l = syslog.level;
+
+tap.test('setmask', function(t) {
+  var mask0 = syslog.setmask(0x6);
+  var mask1 = syslog.setmask(0x6);
+  var mask2 = syslog.setmask(0x6);
+  var mask3 = syslog.upto('LOG_DEBUG');
+  var mask4 = syslog.setmask();
+
+  t.equal(mask1, 0x6);
+  t.equal(mask2, 0x6);
+  t.equal(mask3, mask2);
+  t.equal(mask4, syslog.logUpto('LOG_DEBUG'));
+  t.equal(mask4, 0xff);
+  t.end();
+});
+
+tap.test('logUpto', function(t) {
+  var upto = syslog.logUpto;
+  var mask;
+  
+  mask = upto('LOG_DEBUG');
+  t.equal(mask, 0xff);
+  mask = upto('LOG_INFO');
+  t.equal(mask, 0x7f);
+  t.assert((1 << l.LOG_CRIT) & mask);
+  t.assert((1 << l.LOG_INFO) & mask);
+  t.equal((1 << l.LOG_DEBUG) & mask, 0);
+
+  mask = upto('LOG_NOTICE');
+  t.equal(mask, 0x3f);
+  t.assert((1 << l.LOG_NOTICE) & mask);
+  t.equal((1 << l.LOG_INFO) & mask, 0);
+  t.equal((1 << l.LOG_DEBUG) & mask, 0);
+
+  mask = upto('LOG_ALERT');
+  t.equal(mask, 0x03);
+  t.assert((1 << l.LOG_EMERG) & mask);
+  t.assert((1 << l.LOG_ALERT) & mask);
+  t.equal((1 << l.LOG_CRIT) & mask, 0);
+  t.equal((1 << l.LOG_DEBUG) & mask, 0);
+
+  mask = upto('LOG_EMERG');
+  t.equal(mask, 0x01);
+  t.assert((1 << l.LOG_EMERG) & mask);
+  t.equal((1 << l.LOG_ALERT) & mask, 0);
+  t.equal((1 << l.LOG_CRIT) & mask, 0);
+  t.equal((1 << l.LOG_DEBUG) & mask, 0);
+
+  t.end();
+});
+
+tap.test('upto', function(t) {
+  syslog.upto(l.LOG_NOTICE);
+  t.equal(syslog.curmask(), 0x3f);
+
+  syslog.upto(l.LOG_CRIT);
+  t.equal(syslog.curmask(), 0x07);
+
+  syslog.upto(l.LOG_EMERG);
+  t.equal(syslog.curmask(), 0x01);
+
+  syslog.upto(l.LOG_DEBUG);
+  t.equal(syslog.curmask(), 0xff);
+
+  syslog.upto('LOG_NOTICE');
+  t.equal(syslog.curmask(), 0x3f);
+
+  syslog.upto('LOG_CRIT');
+  t.equal(syslog.curmask(), 0x07);
+
+  syslog.upto('LOG_EMERG');
+  t.equal(syslog.curmask(), 0x01);
+
+  syslog.upto('LOG_DEBUG');
+  t.equal(syslog.curmask(), 0xff);
+
+  t.end();
+});

--- a/test/test-stream.js
+++ b/test/test-stream.js
@@ -1,0 +1,50 @@
+var assert = require('assert');
+var fmt = require('util').format;
+var syslog = require('../');
+var tap = require('tap');
+
+var l = syslog.level;
+
+// Patch out the core syslog() so we can verify its arguments.
+function onLog(callback) {
+  syslog.callback = function() {
+    callback.apply(null, arguments);
+    syslog.callback = null;
+  };
+}
+
+syslog.core.syslog = function() {
+  if (syslog.callback) {
+    syslog.callback.apply(null, arguments);
+    return;
+  }
+};
+
+function test(level, facility) {
+  tap.test(fmt('level=%s facility=%s', level, facility), function(t) {
+    var strm = new syslog.Stream(level, facility);
+    var _level = syslog.toLevel(level);
+    var _facility = syslog.toFacility(facility);
+    var _priority = _level | _facility;
+
+    t.plan(2);
+
+    onLog(function(priority, msg) {
+      t.equal(priority, _priority, 'priority');
+      t.equal(String(msg), 'hello', 'message');
+    });
+
+    strm.end('hello');
+    strm.once('finish', function() {
+      t.end();
+    });
+  });
+}
+
+test(l.LOG_DEBUG);
+test(l.LOG_CRIT);
+test('LOG_CRIT');
+test('LOG_CRIT', syslog.facility.LOG_LOCAL0);
+test('LOG_CRIT', 'LOG_LOCAL7');
+test(l.LOG_INFO, syslog.facility.LOG_LOCAL6);
+test('LOG_EMERG', 'LOG_USER');

--- a/test/test-syslog.js
+++ b/test/test-syslog.js
@@ -1,0 +1,85 @@
+var assert = require('assert');
+var fmt = require('util').format;
+var syslog = require('../');
+var tap = require('tap');
+
+var l = syslog.level;
+
+function h(n) {
+  return '0x' + n.toString(16);
+}
+
+var currentMask;
+
+function setmask(mask) {
+  tap.test(fmt('set mask to %j', mask), function(t) {
+    var last = syslog.setmask(mask);
+    var now = syslog.setmask(mask);
+    console.log('set mask: was %s, set %s, now %s', h(last), h(mask), h(now));
+    currentMask = fmt('mask=%s', h(now));
+    if (mask === 0) {
+      t.equal(last, now);
+    } else {
+      t.equal(mask, now);
+    }
+    t.end();
+  });
+}
+
+var count = 0;
+
+function expect(l, m) {
+  tap.test(fmt('log at %j msg %s', l, m), function(t) {
+    var prefix = fmt('%s index %d level %s EXPECTED: (%s) ',
+                     currentMask, ++count, l, Buffer.isBuffer(m) ? 'buf' : 'str');
+
+    if (Buffer.isBuffer(m)) {
+      m = Buffer(prefix + m);
+    } else {
+      m = prefix + m;
+    }
+
+    syslog.log(l, m, function() {
+      t.end();
+    });
+  });
+}
+
+function masked(l, m) {
+  tap.test(fmt('masked at %j msg %s', l, m), function(t) {
+    var m = fmt('%s level %s NOT EXPECTED: ', currentMask, l, m);
+    syslog.log(l, m, function() {
+      t.end();
+    });
+  });
+}
+
+setmask(0xff);
+
+expect('LOG_CRIT', 'message');
+expect('LOG_CRIT', Buffer('message'));
+expect(l.LOG_CRIT, 'message');
+expect(l.LOG_CRIT, Buffer('message'));
+expect(l.LOG_DEBUG, 'debug');
+
+setmask(syslog.logUpto('LOG_INFO'));
+
+expect(l.LOG_NOTICE, 'should see');
+expect(l.LOG_INFO, 'should see');
+masked(l.LOG_DEBUG, 'should not see');
+
+setmask(syslog.logMask('LOG_INFO'));
+
+masked(l.LOG_NOTICE, 'should see');
+expect(l.LOG_INFO, 'should see');
+masked(l.LOG_DEBUG, 'should not see');
+
+tap.test('MANUAL VERIFICATION ABOVE REQUIRED', function(t) {
+  console.error('%d log messages should be in syslog, looking like:', count);
+  console.error('   ... index 1 level (?) EXPECTED...');
+  console.error('   ... index %d level (?) EXPECTED...', count);
+  console.error('And the indices should be ordered and consecutive');
+  t.end();
+});
+
+return


### PR DESCRIPTION
@bnoordhuis PTAL In particular at core.cc.

I'm wondering if I should be implementing two versions of `core.syslog`, one that takes a buffer, one that takes a String, and then dispatching between them like [fs does](https://github.com/iojs/io.js/blob/v1.x/lib/fs.js#L620-L646). Is that the right way? I thought I'd be able to find out if the [msg](https://github.com/sam-github/modern-syslog/blob/initial/core.cc#L65) argument was a Buffer in C++, and do it there, but I'm not successfully figuring out how to do that.

The `syslog()` core function is most likely going to get called with a String mostly, but in the case of a writeable [stream](https://github.com/sam-github/modern-syslog/blob/initial/index.js#L99-L101), it will be a Buffer. I could ask the stream base to not convert strings to buffers, then I could get either String or Buffer and treat them differently - should I do that?